### PR TITLE
Add status for DRAW games

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,8 @@ match_movement_hash = {
   'MAJOR_DECREASE': 'Major Decrease',
   'MINOR_DECREASE': 'Minor Decrease',
   'PROMOTED': 'Promoted',
-  'DEMOTED': 'Demoted'
+  'DEMOTED': 'Demoted',
+  'STABLE': 'Draw'
 }
 
 maps_hash = {


### PR DESCRIPTION
Current code crashes for some accounts because you forgot to add a movement status for draw games. I added it and also found out that you can actually slightly lose MMR even if the game is a draw (got a -5 on my account).